### PR TITLE
Fix documentation typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ var Search = loopback.getModel('Search');
 
 var query = {
   query: {
-    '*': 'foo'
+    '*': ['foo']
   },
   filters: {
     'type': ['baz']


### PR DESCRIPTION
This is a very useful connector, but this documentation glitch was a bit of a time-waster for me.  Now that I've realised the query is an array, not a string, it's working really nicely.  Hopefully this change will save someone else having to dig into the `search-index` package to get things working :-)
